### PR TITLE
Trailing spaces

### DIFF
--- a/public/resources/highlight-search.js
+++ b/public/resources/highlight-search.js
@@ -17,7 +17,7 @@ highlight.highlightWord = function (word) {
 }
 
 highlight.highlightSearchResults = function (query) {
-  const querySplit = query.split(' ')
+  const querySplit = query.trim().split(' ')
   querySplit.forEach(word => {
     highlight.highlightWord(word)
   })

--- a/search.js
+++ b/search.js
@@ -84,7 +84,7 @@ const searchContext = function (query, content) {
 }
 
 const search = function (query, index) {
-  query = query.toLowerCase()
+  query = query.toLowerCase().trim()
   const results = []
   index.forEach(function (item) {
     const content = item.content

--- a/utest.js
+++ b/utest.js
@@ -594,6 +594,44 @@ describe('Routing', function () {
     }
     waitForSpell()
   })
+  it('Malformed search', function (done) {
+    const app = workerModule.__get__('app')
+    const loadDictionary = workerModule.__get__('loadDictionary')
+    const index = [
+      {
+        'file': 'A',
+        'content': 'Some content',
+        'tags': []
+      },
+      {
+        'file': 'B',
+        'content': 'Some more content',
+        'tags': []
+      }
+    ]
+    workerModule.__set__('index', index)
+    loadDictionary()
+    const testSuggestions = function () {
+      const server = app.listen()
+      request(server).get('/search?query=Brownie+').expect(200, function (error, response) {
+        if (error) {
+          throw error
+        }
+        // We expect to not get any search results back
+        assert.include(response.text, '0 results')
+        done()
+      })
+    }
+    const waitForSpell = function () {
+      const spell = workerModule.__get__('spell')
+      if (spell) {
+        testSuggestions()
+        return
+      }
+      setTimeout(waitForSpell, 10)
+    }
+    waitForSpell()
+  })
 })
 describe('tags', function () {
   it('Schema', function () {

--- a/utest.js
+++ b/utest.js
@@ -336,6 +336,41 @@ describe('Search', function () {
     assert.strictEqual(results[1].label, 'two')
     assert.strictEqual(results[2].label, 'one')
   })
+  it('Trailing and leading space', function () {
+    // This tests that if you search something with a trailing or leading space, it will return sensible results
+    const search = searchModule.__get__('search')
+    const index = []
+    index.push({
+      'file': 'one',
+      'content': 'There is no sensible result here',
+      'tags': []
+    })
+    index.push({
+      'file': 'two',
+      'content': 'More random strings',
+      'tags': []
+    })
+    {
+      // Trailing
+      const results = search('Not found ', index)
+      assert.strictEqual(results.length, 0)
+    }
+    {
+      // Leading
+      const results = search(' Not found', index)
+      assert.strictEqual(results.length, 0)
+    }
+    {
+      // Both
+      const results = search(' Not found ', index)
+      assert.strictEqual(results.length, 0)
+    }
+    {
+      // An actual result
+      const results = search(' More random ', index)
+      assert.strictEqual(results.length, 1)
+    }
+  })
 })
 
 describe('Routing', function () {


### PR DESCRIPTION
Remove trailing and leading spaces from search queries. This is because putting in things like "Brownie " as a search (easily done from a phone keyboard) brought back everything as search results, because it searched for "Brownie" and " ".