### PR TITLE
Increase cache test timeout

### DIFF
--- a/itest.js
+++ b/itest.js
@@ -47,6 +47,8 @@ const foreachRecipeSync = function (predicate) {
 }
 
 describe('Cache', function () {
+  // This can be pretty long running, especially if the files aren't in hte disk cache.
+  this.timeout(5000)
   it('Up to date', function (done) {
     let paths = []
     foreachRecipeSync(function (path) {


### PR DESCRIPTION
The cache tests were failing with:
```
  1) Cache Up to date:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.


  2) Cache Don't delete cache content:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```
as the files were being accessed slowly. Extend the timeout for those tests.